### PR TITLE
Add wyoming-faster-whisper executable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,4 +36,9 @@ setup(
         "Programming Language :: Python :: 3.11",
     ],
     keywords="rhasspy wyoming whisper stt",
+    entry_points={
+        'console_scripts': [
+            'wyoming-faster-whisper = wyoming_faster_whisper:__main__.run'
+        ]
+    },
 )

--- a/wyoming_faster_whisper/__main__.py
+++ b/wyoming_faster_whisper/__main__.py
@@ -132,8 +132,12 @@ async def main() -> None:
 
 # -----------------------------------------------------------------------------
 
+def run():
+    asyncio.run(main())
+
+
 if __name__ == "__main__":
     try:
-        asyncio.run(main())
+        run()
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
This change provides an executable that will be installed into the bin/ directory of the python environment, which is simpler to start up, because the correct python instance is already implied.

Same vein, upstreaming these patches on every update.