### PR TITLE
Fix model identifier retrieval on python3.11+

### DIFF
--- a/wyoming_faster_whisper/download.py
+++ b/wyoming_faster_whisper/download.py
@@ -86,7 +86,7 @@ def download_model(model: FasterWhisperModel, dest_dir: Union[str, Path]) -> Pat
 
     dest_dir.mkdir(parents=True, exist_ok=True)
 
-    model_url = URL_FORMAT.format(model=model)
+    model_url = URL_FORMAT.format(model=model.value)
     with urlopen(model_url) as response:
         with tarfile.open(mode="r|*", fileobj=response) as tar_gz:
             tar_gz.extractall(dest_dir)


### PR DESCRIPTION
From Python 3.11 accessing an enum value will not longer convert to its value representation. Instead a representation of the enum key will be returned.

This broke model download on wyoming-faster-whisper, since it changed the URL under which model downloads would be looked for.

Same as https://github.com/rhasspy/rhasspy3/pull/53