### PR TITLE
Add support to load any huggingface ASR model

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Run a server anyone can connect to:
 ```sh
 script/run --model tiny-int8 --language en --uri 'tcp://0.0.0.0:10300' --data-dir /data --download-dir /data
 ```
+Run with any huggingface model:
+```sh
+script/run --model "distil-whisper/distil-medium.en" --language en --uri 'tcp://0.0.0.0:10300' --data-dir ./data -
+-download-dir ./data
+```
 
 ## Docker Image
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 wyoming==1.2.0
-ctranslate2>=3.17,<4
-tokenizers==0.13.*
+ctranslate2>=3.20,<4
+tokenizers==0.14.*
+transformers==4.35.0
+accelerate==0.24.1

--- a/wyoming_faster_whisper/faster_whisper/__init__.py
+++ b/wyoming_faster_whisper/faster_whisper/__init__.py
@@ -1,1 +1,1 @@
-from .transcribe import WhisperModel
+from .transcribe import ASRModel, HuggingFaceModel, WhisperModel

--- a/wyoming_faster_whisper/handler.py
+++ b/wyoming_faster_whisper/handler.py
@@ -9,7 +9,7 @@ from wyoming.event import Event
 from wyoming.info import Describe, Info
 from wyoming.server import AsyncEventHandler
 
-from .faster_whisper import WhisperModel
+from .faster_whisper import ASRModel
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ class FasterWhisperEventHandler(AsyncEventHandler):
         self,
         wyoming_info: Info,
         cli_args: argparse.Namespace,
-        model: WhisperModel,
+        model: ASRModel,
         model_lock: asyncio.Lock,
         *args,
         **kwargs,


### PR DESCRIPTION
Two changes you may disagree with but I don't know how to solve: 
1. Changing the  `choices` to simply `str` to allow passing arbitrary model url strings.
2. Adding requirements - Accelerate is optional and only needed with the "use_low_cpu_memory" option. If someone only needs regular faster whisper and not huggingface models, we don't need to install torch for example.

This also throws an error while running on the PI