### PR TITLE
Fix whipser -> whisper in console_scripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,6 @@ setup(
     ],
     keywords="rhasspy wyoming whisper stt",
     entry_points={
-        "console_scripts": ["wyoming-faster-whipser = wyoming_faster_whisper.__main__:run"]
+        "console_scripts": ["wyoming-faster-whisper = wyoming_faster_whisper.__main__:run"]
     },
 )


### PR DESCRIPTION
Found a small typo in `setup.py` (`whipser` -> `whisper`) -- this corrects it.