### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.github
+.gitignore
+tests
+.projectile
+pylintrc
+Dockerfile
+*.md
+*.in
+*.ini
+*.cfg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# ctranslate2 does not seem to support newer versions of python
+FROM python:3.9 AS builder
+
+WORKDIR /src
+
+COPY . .
+
+RUN ./script/setup && ./script/package
+
+# ctranslate2 does not seem to support newer versions of python
+FROM python:3.9
+
+RUN --mount=type=bind,from=builder,target=/mnt/builder pip3 install /mnt/builder/src/dist/*.whl
+
+WORKDIR /src
+COPY docker-entrypoint.sh .
+
+EXPOSE 10300/tcp
+VOLUME /data
+LABEL org.opencontainers.image.source=https://github.com/rhasspy/wyoming-faster-whisper
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+python3 -m wyoming_faster_whisper \
+    --uri 'tcp://0.0.0.0:10300' \
+    --data-dir /data \
+    --download-dir /data "$@"


### PR DESCRIPTION
Solves #46.

The image is made to be similar to the one that's published on Docker Hub, but use best practices like a multi-stage build process to make sure the build process is containerized as well.

The Dockerfile would effortlessly support cross-platform builds if the buildx TARGET_ARCH and TARGET_OS could be used. I think that ctranslate2 is the "bottleneck", but it supports the most common archs.

Additionally, it would be nice to include a USER clause to make the container work well in a rootless scenario. But I'm not a native to Python and installing the wheel as non-root caused issues.

Lastly, ctranslate2 failed to install on newer python versions, hence, we're locked to python 3.9.