### PR TITLE
Add default data-dir for Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,15 @@ script/run --model tiny-int8 --language en --uri 'tcp://0.0.0.0:10300' --data-di
 
 The `--model` can also be a HuggingFace model like `Systran/faster-distil-whisper-small.en`
 
+**NOTE**: Models are downloaded to the first `--data-dir` directory.
+
 ## Docker Image
 
 ``` sh
 docker run -it -p 10300:10300 -v /path/to/local/data:/data rhasspy/wyoming-whisper \
-    --data-dir /data --model tiny-int8 --language en
+    --model tiny-int8 --language en
 ```
 
-**NOTE**: Models are downloaded to the first `--data-dir` directory.
+**NOTE**: Models are downloaded to `/data`, so make sure this points to a Docker volume.
 
 [Source](https://github.com/rhasspy/wyoming-addons/tree/master/whisper)

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 cd /usr/src
 .venv/bin/python3 -m wyoming_faster_whisper \
-    --uri 'tcp://0.0.0.0:10300' "$@"
+    --uri 'tcp://0.0.0.0:10300' --data-dir '/data' "$@"


### PR DESCRIPTION
Ensures backwards-compatibility with existing docker-compose.yml installations.
See https://github.com/rhasspy/wyoming-piper/issues/38#issuecomment-3495941254.