### PR TITLE
Update faster-whisper, remove requests dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "wyoming>=1.8,<2",
-    "faster-whisper>=1.1.0,<2",
-    "requests",  # needed by faster-whisper
+    "faster-whisper>=1.2.1,<2",
 ]
 
 [project.urls]


### PR DESCRIPTION
The dependency on requests was removed in faster-whisper 1.2.1.

https://github.com/SYSTRAN/faster-whisper/pull/1382