### PR TITLE
Relax sherpa-onnx pin in sherpa optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ transformers = [
     "transformers[torch]==4.52.4",
 ]
 sherpa = [
-    "sherpa-onnx==1.12.15",
+    "sherpa-onnx>=1.12.19,<2",
 ]
 onnx_asr = [
     "onnx-asr[cpu,hub]==0.7.0",


### PR DESCRIPTION
## Summary
Update the sherpa optional dependency from an exact pin to a bounded compatible range:
- from: sherpa-onnx==1.12.15
- to: sherpa-onnx>=1.12.19,<2

## Why
Version 1.12.15 is no longer available on PyPI, so script/setup --sherpa fails with No matching distribution found.

A bounded range avoids hard failures when one patch release disappears while still keeping major-version compatibility constraints.