### PR TITLE
Set num_threads to 4 by default on sherpa-onnx

### DIFF
--- a/wyoming_faster_whisper/sherpa_handler.py
+++ b/wyoming_faster_whisper/sherpa_handler.py
@@ -48,6 +48,7 @@ class SherpaTranscriber(Transcriber):
 
         # Load model
         self.recognizer = so.OfflineRecognizer.from_transducer(
+            num_threads=4,
             encoder=f"{model_dir}/encoder.int8.onnx",
             decoder=f"{model_dir}/decoder.int8.onnx",
             joiner=f"{model_dir}/joiner.int8.onnx",


### PR DESCRIPTION
Given that probably nobody is running it on a raspberry pi zero (limited to 512mb of ram) and even raspberry pi zero 2 is quad-core, I think it's reasonable to set a minimum value for the number of threads.

A few links comparing the performance of whisper and parakeet models on cpu using different number of threads. The performance doubles when using the Parakeet model with 4 threads vs single thread:

https://k2-fsa.github.io/sherpa/onnx/pretrained_models/whisper/tiny.en.html#real-time-factor-rtf-on-raspberry-pi-4-model-b
https://k2-fsa.github.io/sherpa/onnx/pretrained_models/offline-transducer/nemo-transducer-models.html#rtf-on-rk3588-with-cortex-a76-cpu
https://github.com/ggml-org/whisper.cpp/issues/200
https://github.com/ggml-org/whisper.cpp/issues/3194



Ideally a custom flag would be better, but generally the performance doesn't improve that much after 4 threads and this is a very low effort change...