### PR TITLE
Fix crash on AudioStop without prior AudioChunk (#86, #11)

### DIFF
--- a/wyoming_faster_whisper/dispatch_handler.py
+++ b/wyoming_faster_whisper/dispatch_handler.py
@@ -68,15 +68,29 @@ class DispatchEventHandler(AsyncEventHandler):
             return True
 
         if AudioStop.is_type(event.type):
-            _LOGGER.debug("Audio stoppped")
+            _LOGGER.debug("Audio stopped")
+
+            # No audio was received before AudioStop — return empty transcript.
+            # This happens when HA sends AudioStop without any AudioChunk
+            # (e.g., VAD detected no speech, or the client disconnected early).
+            if self._wav_file is None:
+                _LOGGER.warning("AudioStop received with no audio data")
+                await self.write_event(Transcript(text="").event())
+                self._language = None
+                self._transcriber = None
+                self._transcriber_future = None
+                return False
 
             if self._transcriber is None:
                 # Get transcriber that was loading in the background
-                assert self._transcriber_future is not None
+                if self._transcriber_future is None:
+                    _LOGGER.warning("No transcriber available")
+                    await self.write_event(Transcript(text="").event())
+                    self._wav_file.close()
+                    self._wav_file = None
+                    self._language = None
+                    return False
                 self._transcriber = await self._transcriber_future
-
-            assert self._transcriber is not None
-            assert self._wav_file is not None
 
             self._wav_file.close()
             self._wav_file = None


### PR DESCRIPTION
## Summary

Fixes the `AssertionError` crash when `AudioStop` is received without any preceding `AudioChunk` events.

**Before:** Server crashes with `assert self._wav_file is not None` (or `assert self._transcriber_future is not None`), killing the process and requiring a restart.

**After:** Server returns an empty `Transcript(text="")` and logs a warning, allowing normal operation to continue.

## Root cause

Home Assistant and other Wyoming clients can send `AudioStop` without `AudioChunk` when:
- VAD detects no speech and sends an empty audio stream
- The client disconnects or times out during recording
- The pipeline is interrupted before audio capture begins

The existing bare `assert` statements assume audio was always received, which is not guaranteed by the Wyoming protocol.

## Changes

- Check `self._wav_file is None` before attempting to close it — return empty transcript if no audio was received
- Check `self._transcriber_future is None` before awaiting it — return empty transcript if transcriber wasn't loaded
- Remove bare `assert` statements that crash the server
- Add warning-level log messages for debugging
- Fix typo: "stoppped" -> "stopped"

## Testing

Tested in production on a custom voice assistant pipeline (Pi 5 + Wyoming STT) where this crash occurred regularly during:
- Follow-up listening timeouts (no speech after initial response)
- Wake word false positives (wake detected, no speech follows)
- Fast client disconnects during dual-server STT failover

After this fix, the server handles all these cases gracefully without crashing.

## Related issues

- Closes #86
- Closes #11

Generated with [Claude Code](https://claude.com/claude-code)