### PR TITLE
Fix exposed Docker port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,6 @@ RUN \
 
 COPY ./ ./
 
-EXPOSE 10400
+EXPOSE 10300
 
 ENTRYPOINT ["bash", "docker_run.sh"]


### PR DESCRIPTION
The exposed port in the Dockerfile is incorrect.
Instead of `10300`, it was `10400`.