### PR TITLE
Add FunASR speech-to-text backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,9 @@ sherpa = [
 onnx_asr = [
     "onnx-asr[cpu,hub]==0.11.0",
 ]
+funasr = [
+    "funasr>=1.1.0",
+]
 zeroconf = [
     "wyoming[zeroconf]",
 ]

--- a/wyoming_faster_whisper/const.py
+++ b/wyoming_faster_whisper/const.py
@@ -14,6 +14,7 @@ class SttLibrary(str, Enum):
     TRANSFORMERS = "transformers"
     SHERPA = "sherpa"
     ONNX_ASR = "onnx-asr"
+    FUNASR = "funasr"
 
 
 AUTO_LANGUAGE = "auto"

--- a/wyoming_faster_whisper/funasr_handler.py
+++ b/wyoming_faster_whisper/funasr_handler.py
@@ -1,0 +1,71 @@
+"""Code for transcription using the FunASR library."""
+
+import os
+import wave
+from pathlib import Path
+from typing import Optional, Union
+
+import numpy as np
+
+from .const import Transcriber
+
+_RATE = 16000
+
+# Languages SenseVoice can be told to decode explicitly; otherwise auto-detect.
+_SENSE_VOICE_LANGUAGES = {"auto", "zh", "en", "yue", "ja", "ko"}
+
+
+class FunASRTranscriber(Transcriber):
+    """Wrapper for a FunASR model (SenseVoice / Paraformer / Fun-ASR-Nano)."""
+
+    def __init__(
+        self,
+        model_id: str,
+        cache_dir: Union[str, Path],
+        local_files_only: bool = False,
+        device: str = "cpu",
+    ) -> None:
+        """Initialize model."""
+        # FunASR (hub="hf") downloads via huggingface_hub; honor the cache dir.
+        os.environ.setdefault("HF_HOME", str(Path(cache_dir).resolve()))
+
+        from funasr import AutoModel
+        from funasr.utils.postprocess_utils import rich_transcription_postprocess
+
+        self._postprocess = rich_transcription_postprocess
+        self._is_sense_voice = "SenseVoice" in model_id
+        self.model = AutoModel(
+            model=model_id,
+            hub="hf",
+            device=device,
+            disable_update=True,
+        )
+
+    def transcribe(
+        self,
+        wav_path: Union[str, Path],
+        language: Optional[str],
+        beam_size: int = 5,
+        initial_prompt: Optional[str] = None,
+    ) -> str:
+        """Returns transcription for WAV file.
+
+        WAV file must be 16Khz 16-bit mono audio.
+        """
+        wav_file: wave.Wave_read = wave.open(str(wav_path), "rb")
+        with wav_file:
+            assert wav_file.getframerate() == _RATE, "Sample rate must be 16Khz"
+            assert wav_file.getsampwidth() == 2, "Width must be 16-bit (2 bytes)"
+            assert wav_file.getnchannels() == 1, "Audio must be mono"
+            audio_bytes = wav_file.readframes(wav_file.getnframes())
+
+        audio = np.frombuffer(audio_bytes, dtype=np.int16).astype(np.float32) / 32768.0
+
+        gen_kwargs = {"input": audio, "cache": {}, "use_itn": True, "batch_size_s": 300}
+        if self._is_sense_voice:
+            lang = language if (language in _SENSE_VOICE_LANGUAGES) else "auto"
+            gen_kwargs["language"] = lang
+
+        result = self.model.generate(**gen_kwargs)
+        text = result[0]["text"] if result else ""
+        return self._postprocess(text).strip()

--- a/wyoming_faster_whisper/models.py
+++ b/wyoming_faster_whisper/models.py
@@ -88,6 +88,14 @@ class ModelLoader:
         except ImportError:
             has_onnx_asr = False
             _LOGGER.debug("Onnx-ASR is NOT available")
+        try:
+            from .funasr_handler import FunASRTranscriber
+
+            has_funasr = True
+            _LOGGER.debug("FunASR is available")
+        except ImportError:
+            has_funasr = False
+            _LOGGER.debug("FunASR is NOT available")
 
         # Select speech-to-text library
         if stt_library == SttLibrary.AUTO:
@@ -107,6 +115,7 @@ class ModelLoader:
             ((stt_library == SttLibrary.TRANSFORMERS) and (not has_transformers))
             or ((stt_library == SttLibrary.SHERPA) and (not has_sherpa))
             or ((stt_library == SttLibrary.ONNX_ASR) and (not has_onnx_asr))
+            or ((stt_library == SttLibrary.FUNASR) and (not has_funasr))
         ):
             # Fall back to faster-whisper
             stt_library = SttLibrary.FASTER_WHISPER
@@ -168,6 +177,15 @@ class ModelLoader:
                     model,
                     cache_dir=self.download_dir,
                     local_files_only=self.local_files_only,
+                )
+            elif stt_library == SttLibrary.FUNASR:
+                from .funasr_handler import FunASRTranscriber  # noqa: F811
+
+                transcriber = FunASRTranscriber(
+                    model,
+                    cache_dir=self.download_dir,
+                    local_files_only=self.local_files_only,
+                    device=self.device,
                 )
             else:
                 transcriber = FasterWhisperTranscriber(
@@ -245,6 +263,9 @@ def guess_model(
 
     if stt_library == SttLibrary.ONNX_ASR:
         return "gigaam-v2-rnnt"
+
+    if stt_library == SttLibrary.FUNASR:
+        return "FunAudioLLM/SenseVoiceSmall"
 
     # faster-whisper
     if is_arm:


### PR DESCRIPTION
## What

Adds **FunASR** ([SenseVoice / Paraformer / Fun-ASR-Nano](https://github.com/modelscope/FunASR)) as a selectable STT backend via `--stt-library funasr`, alongside the existing faster-whisper, transformers, sherpa and onnx-asr backends.

SenseVoice is a **non-autoregressive multilingual** model (50+ languages) that is markedly faster than autoregressive Whisper — a good fit for Home Assistant voice pipelines — and is especially strong on Chinese.

## Changes
- `funasr_handler.py` — `FunASRTranscriber` (mirrors `onnx_asr_handler`: 16 kHz/16-bit mono WAV → float32 → `model.generate` → `rich_transcription_postprocess`). SenseVoice language is passed through (`auto`/`zh`/`en`/`yue`/`ja`/`ko`).
- `const.py`: `SttLibrary.FUNASR`.
- `models.py`: dependency probe, AUTO-fallback guard, instantiation branch, and `guess_model` default `FunAudioLLM/SenseVoiceSmall`.
- `pyproject.toml`: optional `funasr` extra.

## Usage
```bash
pip install '.[funasr]'
wyoming-faster-whisper --stt-library funasr --model FunAudioLLM/SenseVoiceSmall --uri tcp://0.0.0.0:10300 --data-dir /data --download-dir /data
```

## Tested
On an H100: `FunASRTranscriber` returns correct text from a 16 kHz/16-bit mono WAV, and the `ModelLoader` wiring resolves the `funasr` backend (enum / CLI choices / `guess_model`). Compiles clean.

Happy to add a README/docs note and a small test to match your conventions — let me know.