### PR TITLE
Fix streaming sherpa quality (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.2.1
+
+- Fix streaming sherpa cutting off the end of utterances (add tail padding before flushing)
+- Default streaming sherpa to the Kroko 2025 zipformer models (mixed-case, punctuated, much better accuracy than the old LibriSpeech model); adds `de`/`es`/`fr` defaults
+- Use `--beam-size` for streaming sherpa decoding (beam search when > 1, greedy otherwise)
+
 ## 3.2.0
 
 - Fix transformers language

--- a/wyoming_faster_whisper/models.py
+++ b/wyoming_faster_whisper/models.py
@@ -145,7 +145,10 @@ class ModelLoader:
                     from .sherpa_handler import SherpaStreamingTranscriber  # noqa: F811
 
                     transcriber = SherpaStreamingTranscriber(
-                        model, self.download_dir, cpu_threads=self.cpu_threads
+                        model,
+                        self.download_dir,
+                        cpu_threads=self.cpu_threads,
+                        beam_size=self.beam_size,
                     )
                 else:
                     from .sherpa_handler import SherpaTranscriber  # noqa: F811
@@ -213,16 +216,22 @@ def guess_model(
     """Automatically guess STT model id."""
     if stt_library == SttLibrary.SHERPA:
         if streaming:
-            # Best available streaming (OnlineRecognizer) model. The streaming
-            # zipformers are English-only, so warn for other languages.
-            if language not in (None, "en"):
-                _LOGGER.warning(
-                    "Streaming sherpa models are English-only; pass --model to "
-                    "use a streaming model for language '%s'",
-                    language,
-                )
+            # Best available streaming (OnlineRecognizer) model. The Kroko
+            # streaming zipformers produce mixed-case, punctuated output with
+            # much better accuracy than the older LibriSpeech models. They are
+            # per-language, so warn for languages we don't have a default for.
+            if language in (None, "en"):
+                return "sherpa-onnx-streaming-zipformer-en-kroko-2025-08-06"
 
-            return "sherpa-onnx-streaming-zipformer-en-2023-06-26"
+            if language in ("de", "es", "fr"):
+                return f"sherpa-onnx-streaming-zipformer-{language}-kroko-2025-08-06"
+
+            _LOGGER.warning(
+                "No default streaming sherpa model for language '%s'; pass "
+                "--model to choose one. Falling back to English.",
+                language,
+            )
+            return "sherpa-onnx-streaming-zipformer-en-kroko-2025-08-06"
 
         if language == "en":
             return "sherpa-onnx-nemo-parakeet-tdt-0.6b-v2-int8"

--- a/wyoming_faster_whisper/sherpa_handler.py
+++ b/wyoming_faster_whisper/sherpa_handler.py
@@ -18,6 +18,11 @@ _LOGGER = logging.getLogger(__name__)
 _RATE = 16000
 _URL_FORMAT = "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/{model_id}.tar.bz2"
 
+# Trailing silence fed to a streaming model before input_finished() so the
+# encoder can flush its final chunk. Without this, the last word(s) of an
+# utterance are dropped. Matches sherpa-onnx's own decode-files examples.
+_TAIL_PADDING_SECONDS = 0.66
+
 
 def _ensure_model(model_id: str, cache_dir: Union[str, Path]) -> Path:
     """Download/extract a sherpa-onnx model if needed and return its directory."""
@@ -133,9 +138,17 @@ class SherpaStreamingTranscriber(Transcriber):
         model_id: str,
         cache_dir: Union[str, Path],
         cpu_threads: int = 4,
+        beam_size: int = 5,
     ) -> None:
         """Initialize model."""
         model_dir = _ensure_model(model_id, cache_dir)
+
+        # A beam size > 1 enables beam search, which is more accurate than the
+        # default greedy decoding at a small latency cost.
+        if beam_size > 1:
+            decoding_method = "modified_beam_search"
+        else:
+            decoding_method = "greedy_search"
 
         # Load model. Streaming zipformer file names are versioned, so locate
         # them by prefix instead of hard-coding.
@@ -146,6 +159,8 @@ class SherpaStreamingTranscriber(Transcriber):
             tokens=str(model_dir / "tokens.txt"),
             num_threads=cpu_threads,
             provider="cpu",
+            decoding_method=decoding_method,
+            max_active_paths=max(beam_size, 1),
         )
 
         # Prime model so that the first transcription will be fast
@@ -205,6 +220,13 @@ class SherpaStreamingSession(StreamingSession):
             self.recognizer.decode_stream(self.stream)
 
     def finish(self) -> str:
+        # Feed trailing silence so the encoder can flush its final chunk;
+        # otherwise the last word(s) of the utterance are cut off.
+        tail_padding = np.zeros(
+            int(_TAIL_PADDING_SECONDS * _RATE), dtype=np.float32
+        )
+        self.stream.accept_waveform(_RATE, tail_padding)
+
         # Signal end of audio and flush any remaining frames.
         self.stream.input_finished()
         while self.recognizer.is_ready(self.stream):


### PR DESCRIPTION
Fixes the issues reported in #94 with `--sherpa-streaming`: end-of-sentence cutoff, ALL-CAPS / no-punctuation output, and poor accuracy.

## Changes

### 1. End of utterance cut off — bug fix
`SherpaStreamingSession.finish()` called `input_finished()` without first feeding **tail padding** (trailing silence). Streaming zipformers encode audio in fixed chunks and need ~0.66s of trailing silence to flush the encoder's final chunk — otherwise the last word(s) are dropped. Now we append tail padding before flushing (matching sherpa-onnx's own `online-decode-files` example).

Verified on `start-a-timer-for-25-minutes`: `...TWENTY FIVE MIN` → `...TWENTY FIVE MINUTES`.

### 2. Newer default streaming model — Kroko 2025
The old default `sherpa-onnx-streaming-zipformer-en-2023-06-26` is LibriSpeech-only (audiobook domain), which is the root cause of the all-caps, unpunctuated, high-WER output on voice commands. Switched the auto default to `sherpa-onnx-streaming-zipformer-en-kroko-2025-08-06` (same zipformer-transducer architecture, drop-in). It produces mixed-case, punctuated output with much better accuracy. Added `de`/`es`/`fr` Kroko defaults too; other languages warn and fall back to English.

| Sample | Old (2023 LibriSpeech) | Kroko 2025 |
|---|---|---|
| shopping list | `AT HAUGHTOCKS TO MY SHOPPING LIST` | `Add hot dogs to my shopping list` |
| timer | `SERVE A TIME HER FOR TWENTY FIVE MIN` | `Start a timer for twenty five minutes` |
| beach boys | `PLAY THE BEECH BOYS AND THE OFFICE` | `play the beach boys in the office` |

### 3. Honor `--beam-size` for streaming
`beam_size` was passed to `start_stream()` but ignored — streaming always used greedy decoding. Now `modified_beam_search` is used when `--beam-size > 1` (the default is 5; 1 on ARM), otherwise greedy.

## Testing
- Existing test suite passes (5/5).
- Manually verified default resolution, tail-padding fix, and greedy-vs-beam decoding against sample voice-command audio.

Note: existing `--sherpa-streaming` users on `auto` will download the new (54 MB) model on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)